### PR TITLE
testcontainers/ryuk continue to run after test is finished

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ lazy val connector =
         "-Wconf:any:error"
       ),
       publishArtifact in GlobalScope in Test := false,
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      fork in Test := true
     )
 
 lazy val root = (project in file("."))

--- a/connector/src/test/scala/zio/container/ZTestContainer.scala
+++ b/connector/src/test/scala/zio/container/ZTestContainer.scala
@@ -2,20 +2,25 @@ package zio.container
 
 import com.dimafeng.testcontainers.CassandraContainer
 import org.testcontainers.lifecycle.Startable
+import org.testcontainers.utility.DockerImageName
 import zio._
+import zio.blocking.{ effectBlocking, Blocking }
 import zio.test.TestFailure
 
 object ZTestContainer {
 
-  def cassandra: ZLayer[Any, TestFailure[Nothing], Has[CassandraContainer]] =
-    managed(CassandraContainer("cassandra:3.11.6")).toLayer
+  def cassandra: ZLayer[Blocking, TestFailure[Nothing], Has[CassandraContainer]] =
+    managed(CassandraContainer(dockerImageNameOverride = DockerImageName.parse("cassandra:3.11.6")))
       .mapError(TestFailure.die)
+      .toLayer
 
-  def managed[T <: Startable](container: T): TaskManaged[T] =
-    ZManaged.makeEffect {
-      container.start()
-      container
-    }(_.stop())
+  def managed[T <: Startable](container: T): RManaged[Blocking, T] =
+    ZManaged.make {
+      effectBlocking {
+        container.start()
+        container
+      }
+    }(c => effectBlocking(c.stop()).orDie)
 
   def apply[C: Tag]: RIO[Has[C], C] =
     ZIO.service[C]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,8 @@ object Dependencies {
 
   val javaStreamsInterop = "1.0.3.5"
 
+  val testContainersVersion = "0.38.8"
+
   val cassandraDependencies = Seq(
     "com.datastax.oss" % "java-driver-core" % cassandraDriverVersion
   )
@@ -23,8 +25,8 @@ object Dependencies {
     "org.slf4j"          % "slf4j-jdk14"                     % "1.7.21",
     "dev.zio"            %% "zio-test"                       % zioVersion,
     "dev.zio"            %% "zio-test-sbt"                   % zioVersion,
-    "com.dimafeng"       %% "testcontainers-scala-core"      % "0.37.0",
-    "com.dimafeng"       %% "testcontainers-scala-cassandra" % "0.37.0"
+    "com.dimafeng"       %% "testcontainers-scala-core"      % testContainersVersion,
+    "com.dimafeng"       %% "testcontainers-scala-cassandra" % testContainersVersion
   ).map(_ % Test)
 
 }


### PR DESCRIPTION
- Bump testcontainers to 0.38.8
- Fork JVM when running tests 
- Use zio.effectBlocking to start and stop container